### PR TITLE
Add option to utilise bitbucket build status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ The plugin creates a global configuration option to supply a username and a pass
 
 In your job, create a Post-Build-Step called **Approve commit on bitbucket**. Configure that step and set the **repository owner** and the **repository name**.
 
+## Build status
+
+In addition to approving your commit on a successful build you can also select the option to mark the commit with a build status (success or fail).
+
 ## Questions, suggestions?
 
 Don't hesitate to file an issue or a pull request. This is my first attempt to creating a Jenkins plugin so appreciate any suggestions.

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket_approve/BitbucketApprover/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket_approve/BitbucketApprover/config.jelly
@@ -8,4 +8,9 @@
   <f:entry title="Approve unstable builds" field="approveUnstable">
     <f:checkbox />
   </f:entry>
+  <f:entry title="Approval Method">
+    <f:radio name="approvalMethod" value="approveOnly" title="Only approve commits" checked="${instance.approvalMethod=='approveOnly'}"/>
+    <f:radio name="approvalMethod" value="statusOnly" title="Only send build status to commits" checked="${instance.approvalMethod=='statusOnly'}"/>
+    <f:radio name="approvalMethod" value="both" title="Send both approval and build status to commits" checked="${instance.approvalMethod=='both'}"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket_approve/BitbucketApprover/help-approvalMethod.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket_approve/BitbucketApprover/help-approvalMethod.jelly
@@ -1,0 +1,3 @@
+<div>
+Whether you want to approve commits, send build status to commits or do both
+</div>


### PR DESCRIPTION
Last week Bitbucket added the ability to mark a commit with a build status. (see https://blog.bitbucket.org/2015/11/18/introducing-the-build-status-api-for-bitbucket-cloud/)

This pull request add's an option for the user to switch from a default of approve only (i.e. the current behavior), to either build status only, or sending both.
